### PR TITLE
feat(routing): allow html5 routing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ import {
 } from '@nebular/auth';
 
 const routes: Routes = [
-  { path: 'pages', loadChildren: 'app/pages/pages.module#PagesModule' },
+  { path: 'pages', loadChildren: './pages/pages.module#PagesModule' },
   {
     path: 'auth',
     component: NbAuthComponent,
@@ -46,7 +46,7 @@ const routes: Routes = [
 ];
 
 const config: ExtraOptions = {
-  useHash: true,
+  useHash: false,
 };
 
 @NgModule({

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>ngx-admin Demo Application</title>
-
+  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
fetaure

**What is the current behavior?** 
currently, by default, routing uses HashLocationStrategy (e.g. http://localhost:4200/#/pages/ui-features/buttons)

**What is the new behavior (if this is a feature change)?**
the suggested changes allow using html5 routing with PathLocationStrategy (e.g. http://localhost:4200/pages/ui-features/buttons)
this is enabled with ng serve, even after page refresh

**Other information:**
changed `useHash` to `false` in app-routing.module.ts
and added `<base href="/">` in index.html

**Note:**
for this to work, the web server should be configured to redirect all requests to index.html

by the way, thank you for the great work :)