### PR TITLE
add compodoc documentation generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 npm-debug.log
 testem.log
 /typings
+/docs
 
 # e2e
 /e2e/*.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,6 +241,176 @@
       "resolved": "https://registry.npmjs.org/@asymmetrik/angular2-leaflet/-/angular2-leaflet-2.1.4.tgz",
       "integrity": "sha1-PVUVX3cAh1O85A8K9Tqip+wjkWs="
     },
+    "@compodoc/compodoc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.0.1.tgz",
+      "integrity": "sha512-+hXITPup4tL4Jh3lo52YojXvshjcna95IzFm5FxEBM3vpXK4D+e1y6v7uUsVW2UopXfxv16uXBKm6b3GiaPTaQ==",
+      "dev": true,
+      "requires": {
+        "@compodoc/ngd-transformer": "2.0.0-alpha.5",
+        "cheerio": "1.0.0-rc.2",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "findit": "2.0.0",
+        "fs-extra": "4.0.1",
+        "glob": "7.1.2",
+        "gulp-util": "3.0.8",
+        "handlebars": "4.0.11",
+        "html-entities": "1.2.1",
+        "json5": "0.5.1",
+        "live-server": "1.1.0",
+        "lodash": "4.17.4",
+        "lunr": "1.0.0",
+        "marked": "0.3.6",
+        "os-name": "2.0.1",
+        "shelljs": "0.7.8",
+        "typescript": "2.5.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "typescript": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+          "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "@compodoc/ngd-core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-wZNC0HhZCu3KufvulriGfEayjmniEih25R3CvxIvEMVk4kCvVA6giLhYzKgIl0J9JC5KKYdXuu9SlVXr9Niyug==",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "typescript": "2.5.3"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+          "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+          "dev": true
+        }
+      }
+    },
+    "@compodoc/ngd-transformer": {
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@compodoc/ngd-transformer/-/ngd-transformer-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-gA6AgVgPXvlL4MtzzgMWB4FzQsQHndXpRQGWZ9NzQFpl+Qcyko+CMVU+ssqSwp/JAidL/3l3fk/aDDlymhJJag==",
+      "dev": true,
+      "requires": {
+        "@compodoc/ngd-core": "2.0.0-alpha.3",
+        "dot": "1.1.2",
+        "fs-extra": "4.0.1",
+        "viz.js": "1.8.0"
+      }
+    },
     "@nebular/auth": {
       "version": "2.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@nebular/auth/-/auth-2.0.0-rc.2.tgz",
@@ -436,6 +606,16 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "ambi": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
+    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -510,6 +690,21 @@
         "arrify": "1.0.1",
         "micromatch": "2.3.11"
       }
+    },
+    "apache-crypt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.1.2.tgz",
+      "integrity": "sha1-ggeCozu2pf0nEggvDtOiTjybAhQ=",
+      "dev": true,
+      "requires": {
+        "unix-crypt-td-js": "1.0.0"
+      }
+    },
+    "apache-md5": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.0.6.tgz",
+      "integrity": "sha1-RwI51AxU58Mt2dbrEbw1eOzJA8I=",
+      "dev": true
     },
     "app-root-path": {
       "version": "2.0.1",
@@ -866,6 +1061,15 @@
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -881,6 +1085,12 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
@@ -1283,6 +1493,45 @@
         "color-name": "1.1.2"
       }
     },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash": "4.17.4",
+        "parse5": "3.0.2"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+          "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.1",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.2"
+          }
+        }
+      }
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1431,6 +1680,12 @@
         "is-supported-regexp-flag": "1.0.0"
       }
     },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1465,6 +1720,12 @@
         "source-map": "0.5.6",
         "sprintf-js": "1.0.3"
       }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
     },
     "collections": {
       "version": "0.2.2",
@@ -1768,6 +2029,16 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.1"
+      }
+    },
     "cosmiconfig": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
@@ -1863,6 +2134,15 @@
         "pbkdf2": "3.0.13",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "csextends": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.1.1.tgz",
+      "integrity": "sha1-zFPBNJ+vfwrmzfb2xKTZFW08TsE=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "1.12.7"
       }
     },
     "css-color-names": {
@@ -2334,6 +2614,12 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -2673,6 +2959,12 @@
         "domelementtype": "1.3.0"
       }
     },
+    "dot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.2.tgz",
+      "integrity": "sha1-xzdwGfxOVQeYkosrmv62ar+h8vk=",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -2714,6 +3006,16 @@
         }
       }
     },
+    "eachr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
+      "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -2723,6 +3025,12 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "editions": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
+      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3152,6 +3460,16 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
+    "extendr": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.2.2.tgz",
+      "integrity": "sha1-xuRv5tkLLj6IEqZlS9YYLL+RzQY=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
+    },
     "external-editor": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
@@ -3172,6 +3490,17 @@
         "is-extglob": "1.0.0"
       }
     },
+    "extract-opts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
+      "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
+      "dev": true,
+      "requires": {
+        "eachr": "3.2.0",
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
+    },
     "extract-text-webpack-plugin": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
@@ -3189,6 +3518,24 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      },
+      "dependencies": {
+        "time-stamp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+          "dev": true
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -3320,6 +3667,12 @@
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
       }
+    },
+    "findit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+      "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
+      "dev": true
     },
     "flat-cache": {
       "version": "1.2.2",
@@ -3662,6 +4015,15 @@
         "minimatch": "3.0.4"
       }
     },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3672,6 +4034,65 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.2",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.0"
+      }
     },
     "handle-thing": {
       "version": "1.2.5",
@@ -3794,6 +4215,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -4017,6 +4447,25 @@
         }
       }
     },
+    "http-auth": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-2.4.11.tgz",
+      "integrity": "sha1-YfAkpuDnxIk0lEiVyHoTlVCcYZs=",
+      "dev": true,
+      "requires": {
+        "apache-crypt": "1.1.2",
+        "apache-md5": "1.0.6",
+        "node-uuid": "1.4.8"
+      },
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        }
+      }
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -4209,6 +4658,22 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "dev": true
+    },
+    "ignorefs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
+      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "ignorepatterns": "1.1.0"
+      }
+    },
+    "ignorepatterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
+      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4=",
       "dev": true
     },
     "image-size": {
@@ -5288,6 +5753,187 @@
         "object-assign": "4.1.1"
       }
     },
+    "live-server": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.1.0.tgz",
+      "integrity": "sha1-pp8ObKWB4DkapXlBlw4XwwjdSGk=",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "connect": "3.4.1",
+        "cors": "2.8.4",
+        "event-stream": "3.3.4",
+        "faye-websocket": "0.11.1",
+        "http-auth": "2.4.11",
+        "morgan": "1.9.0",
+        "object-assign": "4.1.1",
+        "opn": "5.1.0",
+        "proxy-middleware": "0.15.0",
+        "send": "0.16.1",
+        "serve-index": "1.9.0",
+        "watchr": "2.6.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
+        "connect": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
+          "integrity": "sha1-ohNh0/QJnvdhzabcSpc7seuwo00=",
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "finalhandler": "0.4.1",
+            "parseurl": "1.3.1",
+            "utils-merge": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true
+        },
+        "event-stream": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+          "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+          "dev": true,
+          "requires": {
+            "duplexer": "0.1.1",
+            "from": "0.1.7",
+            "map-stream": "0.1.0",
+            "pause-stream": "0.0.11",
+            "split": "0.3.3",
+            "stream-combiner": "0.0.4",
+            "through": "2.3.8"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.6.5"
+          }
+        },
+        "finalhandler": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "unpipe": "1.0.0"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "opn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+          "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "1.1.0"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -5323,6 +5969,60 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -5342,6 +6042,38 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5355,11 +6087,44 @@
       "dev": true,
       "optional": true
     },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
     "lodash.tail": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -5459,10 +6224,22 @@
         "yallist": "2.1.2"
       }
     },
+    "lunr": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-1.0.0.tgz",
+      "integrity": "sha1-XJJ2ySyRrDWpJBtQGNRnI9kuL18=",
+      "dev": true
+    },
     "macaddress": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "dev": true
+    },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
       "dev": true
     },
     "magic-string": {
@@ -5490,6 +6267,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
       "dev": true
     },
     "matcher-collection": {
@@ -5699,6 +6482,36 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "dev": true,
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5715,6 +6528,15 @@
         "array-union": "1.0.2",
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
+      }
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
       }
     },
     "mute-stream": {
@@ -6215,6 +7037,16 @@
         "lcid": "1.0.0"
       }
     },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "dev": true,
+      "requires": {
+        "macos-release": "1.1.0",
+        "win-release": "1.1.1"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -6283,6 +7115,15 @@
       "dev": true,
       "requires": {
         "error-ex": "1.3.1"
+      }
+    },
+    "parse5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
+      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.74"
       }
     },
     "parsejson": {
@@ -7241,6 +8082,12 @@
         "ipaddr.js": "1.4.0"
       }
     },
+    "proxy-middleware": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+      "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+      "dev": true
+    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -7493,6 +8340,15 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7630,6 +8486,12 @@
       "requires": {
         "is-finite": "1.0.2"
       }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
     },
     "request": {
       "version": "2.81.0",
@@ -7792,6 +8654,16 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "safefs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
+      "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "graceful-fs": "4.1.11"
+      }
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
@@ -7840,6 +8712,38 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scandirectory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
+      "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+      "dev": true,
+      "requires": {
+        "ignorefs": "1.2.0",
+        "safefs": "3.2.2",
+        "taskgroup": "4.3.1"
+      },
+      "dependencies": {
+        "safefs": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
+          "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "taskgroup": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
+          "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+          "dev": true,
+          "requires": {
+            "ambi": "2.5.0",
+            "csextends": "1.1.1"
+          }
+        }
+      }
     },
     "schema-utils": {
       "version": "0.3.0",
@@ -8072,6 +8976,17 @@
         "array-map": "0.0.0",
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
       }
     },
     "signal-exit": {
@@ -8363,6 +9278,12 @@
       "requires": {
         "source-map": "0.5.6"
       }
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -8922,6 +9843,18 @@
         "inherits": "2.0.3"
       }
     },
+    "taskgroup": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.0.1.tgz",
+      "integrity": "sha1-CHNsmyRoOxQ0d0Ix60tzqnw/ebU=",
+      "dev": true,
+      "requires": {
+        "ambi": "2.5.0",
+        "eachr": "3.2.0",
+        "editions": "1.3.3",
+        "extendr": "3.2.2"
+      }
+    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -9199,6 +10132,15 @@
         "mime-types": "2.1.15"
       }
     },
+    "typechecker": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz",
+      "integrity": "sha1-+XuV9RsDhBchLWd9RaNz7nvO1+Y=",
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3"
+      }
+    },
     "typeface-exo": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/typeface-exo/-/typeface-exo-0.0.22.tgz",
@@ -9266,6 +10208,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
+    },
+    "unix-crypt-td-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz",
+      "integrity": "sha1-HAgkFQSBvHoB1J6Y8exmjYJBLzs=",
       "dev": true
     },
     "unpipe": {
@@ -9437,6 +10385,23 @@
         "extsprintf": "1.0.2"
       }
     },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "viz.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.0.tgz",
+      "integrity": "sha1-4Mta0kE2jjWxpulgaR66RUwklR8=",
+      "dev": true
+    },
     "vlq": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
@@ -9477,6 +10442,22 @@
         "async": "2.5.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
+      }
+    },
+    "watchr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.6.0.tgz",
+      "integrity": "sha1-51xCOxC+eSZ6DD73bi6hBP4CZ6U=",
+      "dev": true,
+      "requires": {
+        "eachr": "3.2.0",
+        "extendr": "3.2.2",
+        "extract-opts": "3.3.1",
+        "ignorefs": "1.2.0",
+        "safefs": "4.1.0",
+        "scandirectory": "2.5.0",
+        "taskgroup": "5.0.1",
+        "typechecker": "4.4.1"
       }
     },
     "wbuf": {
@@ -9950,6 +10931,15 @@
             "strip-ansi": "3.0.1"
           }
         }
+      }
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "lint:ci": "npm run lint && npm run lint:styles",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e",
+    "docs": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs",
+    "docs:serve": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs -s",
     "prepush": "npm run lint:ci"
   },
   "dependencies": {
@@ -69,6 +71,7 @@
     "@angular/cli": "1.2.6",
     "@angular/compiler-cli": "4.3.2",
     "@angular/language-service": "4.3.2",
+    "@compodoc/compodoc": "^1.0.1",
     "@types/d3-color": "1.0.4",
     "@types/jasmine": "2.5.38",
     "@types/jasminewd2": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint:ci": "npm run lint && npm run lint:styles",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e",
-    "docs": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs",
-    "docs:serve": "./node_modules/.bin/compodoc -p src/tsconfig.app.json -d docs -s",
+    "docs": "compodoc -p src/tsconfig.app.json -d docs",
+    "docs:serve": "compodoc -p src/tsconfig.app.json -d docs -s",
     "prepush": "npm run lint:ci"
   },
   "dependencies": {


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Feature

**What is the new behavior (if this is a feature change)?**
this PR adds support for [compodoc](https://compodoc.github.io/website/) angular documentation generator (as discussed in #1326)

**Other information:**
`npm run docs` builds the documentations in `docs` folder.
`npm run docs:serve` builds the documentations and serves it on http://localhost:8080/

**More information:**
https://compodoc.github.io/website/guides/getting-started.html
https://github.com/compodoc/compodoc



