### PR TITLE
feat(cards): add enhanced cards (accent, reveal, flip)

### DIFF
--- a/src/app/@theme/components/cards/card-accent/card-accent.component.scss
+++ b/src/app/@theme/components/cards/card-accent/card-accent.component.scss
@@ -1,0 +1,25 @@
+@import '../../../styles/themes';
+
+.accent {
+  position: absolute;
+  width: 100%;
+  height: nb-theme(card-border-radius);
+  border-top-left-radius: nb-theme(card-border-radius);
+  border-top-right-radius: nb-theme(card-border-radius);
+}
+
+.accent-primary {
+  background-color: nb-theme(color-primary);
+}
+.accent-success {
+  background-color: nb-theme(color-success);
+}
+.accent-info {
+  background-color: nb-theme(color-info);
+}
+.accent-warning {
+  background-color: nb-theme(color-warning);
+}
+.accent-danger {
+  background-color: nb-theme(color-danger);
+}

--- a/src/app/@theme/components/cards/card-accent/card-accent.component.ts
+++ b/src/app/@theme/components/cards/card-accent/card-accent.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input} from '@angular/core';
+
+@Component({
+  selector: 'ngx-card-accent',
+  template: `
+    <div class="accent" [ngClass]="'accent-' + type" [style.background-color] = "color"></div>
+  `,
+  styleUrls: ['./card-accent.component.scss'],
+})
+export class CardAccentComponent {
+
+  @Input() type = '';
+  @Input() color = '';
+
+}

--- a/src/app/@theme/components/cards/card/card.component.html
+++ b/src/app/@theme/components/cards/card/card.component.html
@@ -1,0 +1,7 @@
+<nb-card size="{{size}}" status="{{status}}">
+  <ngx-card-accent type="{{accent}}"></ngx-card-accent>
+  <ng-content></ng-content>
+  <nb-card-header><ng-content select="ngx-card-header"></ng-content></nb-card-header>
+  <nb-card-body><ng-content select="ngx-card-body"></ng-content></nb-card-body>
+  <nb-card-footer><ng-content select="ngx-card-footer"></ng-content></nb-card-footer>
+</nb-card>

--- a/src/app/@theme/components/cards/card/card.component.scss
+++ b/src/app/@theme/components/cards/card/card.component.scss
@@ -1,0 +1,35 @@
+@import '../../../styles/themes';
+
+nb-card-header:empty, nb-card-body:empty, nb-card-footer:empty {
+  display: none;
+}
+
+nb-card {
+  position: relative;
+}
+
+:host-context(.card-back)  nb-card {
+  height: 100%;
+}
+
+:host-context(.ngx-card-xxsmall) nb-card {
+  height: nb-theme(card-height-xxsmall);
+}
+:host-context(.ngx-card-xsmall) nb-card {
+  height: nb-theme(card-height-xsmall);
+}
+:host-context(.ngx-card-small) nb-card {
+  height: nb-theme(card-height-small);
+}
+:host-context(.ngx-card-medium) nb-card {
+  height: nb-theme(card-height-medium);
+}
+:host-context(.ngx-card-large) nb-card {
+  height: nb-theme(card-height-large);
+}
+:host-context(.ngx-card-xlarge) nb-card {
+  height: nb-theme(card-height-xlarge);
+}
+:host-context(.ngx-card-xxlarge) nb-card {
+  height: nb-theme(card-height-xxlarge);
+}

--- a/src/app/@theme/components/cards/card/card.component.ts
+++ b/src/app/@theme/components/cards/card/card.component.ts
@@ -1,0 +1,16 @@
+import { RevealCardComponent } from '../reveal-card/reveal-card.component';
+import { NbCardComponent } from '@nebular/theme/components/card/card.component';
+import { Component, Input, OnInit, ViewContainerRef } from '@angular/core';
+
+@Component({
+  selector: 'ngx-card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.scss'],
+})
+export class CardComponent {
+
+  @Input() size = '';
+  @Input() status = '';
+  @Input() accent = '';
+
+}

--- a/src/app/@theme/components/cards/flip-card/flip-card.component.html
+++ b/src/app/@theme/components/cards/flip-card/flip-card.component.html
@@ -1,0 +1,16 @@
+<div class="flipcard-container">
+  <div class="flipcard ngx-card-{{size}}" [ngClass]="{'flipped': flipped}">
+    <div class="card-front">
+      <ng-content select=".card-front"></ng-content>
+      <a class="flip-button" (click)="flipped = true">
+        <i class="fa fa-ellipsis-h" aria-hidden="true"></i>
+      </a>
+    </div>
+    <div class="card-back">
+      <ng-content select=".card-back"></ng-content>
+      <a class="flip-button" (click)="flipped = false">
+        <i class="fa fa-reply" aria-hidden="true"></i>
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/app/@theme/components/cards/flip-card/flip-card.component.scss
+++ b/src/app/@theme/components/cards/flip-card/flip-card.component.scss
@@ -1,0 +1,86 @@
+@import '../../../styles/themes';
+
+.flipcard-container {
+  -webkit-perspective: 1200px;
+     -moz-perspective: 1200px;
+       -o-perspective: 1200px;
+          perspective: 1200px;
+    margin-bottom: nb-theme(card-padding);
+  }
+.flipcard.flipped {
+	-webkit-transform: rotateY( 180deg );
+     -moz-transform: rotateY( 180deg );
+       -o-transform: rotateY( 180deg );
+          transform: rotateY( 180deg );
+  }
+.flipcard {
+  -webkit-transition: -webkit-transform 0.5s;
+     -moz-transition: -moz-transform 0.5s;
+       -o-transition: -o-transform 0.5s;
+          transition: transform 0.5s;
+  -webkit-transform-style: preserve-3d;
+     -moz-transform-style: preserve-3d;
+       -o-transform-style: preserve-3d;
+          transform-style: preserve-3d;
+  position: relative;
+  display: flex;
+  margin-bottom: nb-theme(card-padding);
+}
+
+.card-front, .card-back {
+	-webkit-backface-visibility: hidden;
+     -moz-backface-visibility: hidden;
+       -o-backface-visibility: hidden;
+          backface-visibility: hidden;
+}
+
+.card-front {
+	z-index: 2;
+}
+
+.card-back {
+  -webkit-transform: rotateY( 180deg );
+    -moz-transform: rotateY( 180deg );
+      -o-transform: rotateY( 180deg );
+          transform: rotateY( 180deg );
+          z-index: 3;
+}
+
+.card-front, .card-back {
+  width: 100%;
+}
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    .card-front, .card-back {
+        -ms-backface-visibility: visible;
+            backface-visibility: visible;
+    }
+
+    .card-back {
+        visibility: hidden;
+        -ms-transition: all 0.2s cubic-bezier(0.92, 0.01, 0.83, 0.67);
+    }
+    .card-front {
+      z-index: 4;
+    }
+    .flipcard.flipped .card-back {
+      z-index: 5;
+      visibility: visible;
+    }
+}
+.flipcard.flipped .card-back {
+  margin-left: -100%;
+}
+.flipcard:not(.flipped) .card-front {
+  margin-right: -100%;
+}
+
+.flip-button {
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  display: block;
+  padding: nb-theme(card-padding);
+  margin-bottom: nb-theme(card-margin);
+  z-index: 5;
+}

--- a/src/app/@theme/components/cards/flip-card/flip-card.component.ts
+++ b/src/app/@theme/components/cards/flip-card/flip-card.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ngx-flip-card',
+  templateUrl: './flip-card.component.html',
+  styleUrls: ['./flip-card.component.scss'],
+})
+export class FlipCardComponent {
+
+  @Input() flipped = false;
+  @Input() size = 'medium';
+
+}

--- a/src/app/@theme/components/cards/index.ts
+++ b/src/app/@theme/components/cards/index.ts
@@ -1,0 +1,4 @@
+export * from './card/card.component';
+export * from './card-accent/card-accent.component';
+export * from './flip-card/flip-card.component';
+export * from './reveal-card/reveal-card.component';

--- a/src/app/@theme/components/cards/reveal-card/reveal-card.component.html
+++ b/src/app/@theme/components/cards/reveal-card/reveal-card.component.html
@@ -1,0 +1,16 @@
+<div class="revealcard ngx-card-{{size}}" [ngClass]="{'revealed': revealed}">
+  <div class="card-front">
+      <ng-content select=".card-front"></ng-content>
+      <a class="reveal-button" (click)="revealed = true">
+        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+      </a>
+  </div>
+  <div class="card-back">
+    <div class="reveal">
+        <ng-content select=".card-back"></ng-content>
+        <a class="reveal-button" (click)="revealed = false">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </a>
+    </div>
+  </div>
+</div>

--- a/src/app/@theme/components/cards/reveal-card/reveal-card.component.scss
+++ b/src/app/@theme/components/cards/reveal-card/reveal-card.component.scss
@@ -1,0 +1,46 @@
+@import '../../../styles/themes';
+
+.revealcard {
+  width: 100%;
+  position: relative;
+  display: flex;
+}
+.card-front, .reveal {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.card-front {
+  z-index: 1;
+}
+.reveal {
+  top: 100%;
+  position: absolute;
+  transition: all 0.3s ease-out;
+  width: 100%;
+  margin-bottom: nb-theme(card-padding);
+}
+.revealcard.revealed > .card-back > .reveal {
+  top: 0;
+  z-index: 2;
+}
+.reveal-button {
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  display: block;
+  padding: nb-theme(card-padding);
+  margin-bottom: nb-theme(card-padding);
+  z-index: 2;
+}
+.reveal > .reveal-button {
+  top: 0;
+}
+.card-back {
+  position: absolute;
+  height:  calc(100% - (#{nb-theme(card-margin)} + #{nb-theme(card-padding)}));
+  width: 100%;
+  bottom: calc(#{nb-theme(card-margin)} + #{nb-theme(card-padding)});
+  overflow: hidden;
+}

--- a/src/app/@theme/components/cards/reveal-card/reveal-card.component.ts
+++ b/src/app/@theme/components/cards/reveal-card/reveal-card.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'ngx-reveal-card',
+  templateUrl: './reveal-card.component.html',
+  styleUrls: ['./reveal-card.component.scss'],
+})
+export class RevealCardComponent {
+
+  @Input() revealed = false;
+  @Input() size = 'medium';
+
+}

--- a/src/app/@theme/components/index.ts
+++ b/src/app/@theme/components/index.ts
@@ -4,3 +4,4 @@ export * from './search-input/search-input.component';
 export * from './tiny-mce/tiny-mce.component';
 export * from './theme-settings/theme-settings.component';
 export * from './theme-switcher/theme-switcher.component';
+export * from './cards';

--- a/src/app/@theme/theme.module.ts
+++ b/src/app/@theme/theme.module.ts
@@ -24,6 +24,10 @@ import {
   ThemeSettingsComponent,
   ThemeSwitcherComponent,
   TinyMCEComponent,
+  CardComponent,
+  CardAccentComponent,
+  FlipCardComponent,
+  RevealCardComponent,
 } from './components';
 import { CapitalizePipe, PluralPipe, RoundPipe, TimingPipe } from './pipes';
 import {
@@ -58,6 +62,10 @@ const COMPONENTS = [
   SearchInputComponent,
   ThemeSettingsComponent,
   TinyMCEComponent,
+  CardComponent,
+  CardAccentComponent,
+  FlipCardComponent,
+  RevealCardComponent,
   OneColumnLayoutComponent,
   SampleLayoutComponent,
   ThreeColumnsLayoutComponent,

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -58,3 +58,9 @@
     <ngx-security-cameras></ngx-security-cameras>
   </div>
 </div>
+
+<div class="row">
+  <div class="col-xxxl-12">
+    <ngx-enhanced-cards></ngx-enhanced-cards>
+  </div>
+</div>

--- a/src/app/pages/dashboard/dashboard.module.ts
+++ b/src/app/pages/dashboard/dashboard.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { AngularEchartsModule } from 'ngx-echarts';
 
 import { ThemeModule } from '../../@theme/theme.module';
@@ -19,6 +19,7 @@ import { SolarComponent } from './solar/solar.component';
 import { PlayerComponent } from './rooms/player/player.component';
 import { TrafficComponent } from './traffic/traffic.component';
 import { TrafficChartComponent } from './traffic/traffic-chart.component';
+import { EnhancedCardsComponent } from './enhanced-cards/enhanced-cards.component';
 
 
 @NgModule({
@@ -44,6 +45,8 @@ import { TrafficChartComponent } from './traffic/traffic-chart.component';
     SolarComponent,
     TrafficComponent,
     TrafficChartComponent,
+    EnhancedCardsComponent,
   ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
 })
 export class DashboardModule { }

--- a/src/app/pages/dashboard/enhanced-cards/enhanced-cards.component.html
+++ b/src/app/pages/dashboard/enhanced-cards/enhanced-cards.component.html
@@ -1,0 +1,63 @@
+<div class="row">
+  <div class="col-xl-4 col-md-6 col-sm-12">
+    <ngx-card size="medium" accent="info">
+      <ngx-card-header>Card with accent</ngx-card-header>
+      <ngx-card-body>
+        <p>some text</p>
+        <p>some text</p>
+        <p>some text</p>
+        <p>some text</p>
+        <p>some text</p>
+    </ngx-card-body>
+      <ngx-card-footer>footer</ngx-card-footer>
+    </ngx-card>
+  </div>
+
+  <div class="col-xl-4 col-md-6 col-sm-12">
+    <ngx-reveal-card size="medium">
+      <ngx-card class="card-front" accent="warning">
+        <ngx-card-header>Reveal Card</ngx-card-header>
+        <ngx-card-body>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+        </ngx-card-body>
+        <ngx-card-footer>footer</ngx-card-footer>
+      </ngx-card>
+      <ngx-card class="card-back">
+        <ngx-card-body>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+        </ngx-card-body>
+      </ngx-card>
+    </ngx-reveal-card>
+  </div>
+
+  <div class="col-xl-4 col-md-6 col-sm-12">
+    <ngx-flip-card size="medium">
+      <ngx-card class="card-front" accent="success">
+        <ngx-card-header>Flip Card</ngx-card-header>
+        <ngx-card-body>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+          <p>some text</p>
+        </ngx-card-body>
+        <ngx-card-footer>footer</ngx-card-footer>
+      </ngx-card>
+      <ngx-card class="card-back">
+        <ngx-card-body>
+          back
+        </ngx-card-body>
+      </ngx-card>
+    </ngx-flip-card>
+  </div>
+
+</div>
+

--- a/src/app/pages/dashboard/enhanced-cards/enhanced-cards.component.ts
+++ b/src/app/pages/dashboard/enhanced-cards/enhanced-cards.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'ngx-enhanced-cards',
+  templateUrl: './enhanced-cards.component.html',
+  styleUrls: ['./enhanced-cards.component.scss'],
+})
+export class EnhancedCardsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Feature

**What is the new behavior (if this is a feature change)?**
this PR adds some enhancements to the Nebular cards. 

**Accents:**
Add card accent as follows:
`<ngx-card accent="success"></ngx-card>`
this possible values include: `['primary', 'info', 'success', 'warning', 'danger']`
it uses the colors defined in the active theme.

**Reveal Card:**
similar to card reveal available in [materializecss](http://materializecss.com/cards.html)

**Flip Card:**
inspired by the [rotating cards](http://demos.creative-tim.com/rotating-card?_ga=2.231945695.1119096132.1509236267-299706646.1498757143) from creative-tim

this is a working demo (at the bottom of dashboard page)
https://hatemhosny.github.io/ngx-admin-demos

this is just a basic working demo. It will need to be put in a better design form.
