### PR TITLE
feature: breadcrumbs

### DIFF
--- a/src/app/@core/core.module.ts
+++ b/src/app/@core/core.module.ts
@@ -5,6 +5,7 @@ import { NbAuthModule, NbDummyAuthProvider } from '@nebular/auth';
 import { throwIfAlreadyLoaded } from './module-import-guard';
 import { DataModule } from './data/data.module';
 import { AnalyticsService } from './utils/analytics.service';
+import { BreadcrumbsService } from './utils/breadcrumbs.service';
 
 const NB_CORE_PROVIDERS = [
   ...DataModule.forRoot().providers,
@@ -22,6 +23,7 @@ const NB_CORE_PROVIDERS = [
     },
   }).providers,
   AnalyticsService,
+  BreadcrumbsService,
 ];
 
 @NgModule({

--- a/src/app/@core/utils/breadcrumbs.service.ts
+++ b/src/app/@core/utils/breadcrumbs.service.ts
@@ -1,0 +1,154 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class BreadcrumbsService {
+
+  private routesFriendlyNames: Map<string, string> = new Map<string, string>();
+  private routesFriendlyNamesRegex: Map<string, string> = new Map<string, string>();
+  private routesWithCallback: Map<string, (string: string) => string> = new Map<string, (string: string) => string>();
+  private routesWithCallbackRegex: Map<string, (string: string) => string> = new Map<string, (string: string) => string>();
+  private hideRoutes: any = new Array<string>();
+  private hideRoutesRegex: any = new Array<string>();
+  private noBreadcrumbsRoutes: any = new Array<string>();
+  private noBreadcrumbsRoutesRegex: any = new Array<string>();
+
+  /**
+   * Specify a friendly name for the corresponding route.
+   *
+   * @param route
+   * @param name
+   */
+  addFriendlyNameForRoute(route: string, name: string): void {
+    this.routesFriendlyNames.set(route, name);
+  }
+
+  /**
+   * Specify a friendly name for the corresponding route matching a regular expression.
+   *
+   * @param route
+   * @param name
+   */
+  addFriendlyNameForRouteRegex(routeRegex: string, name: string): void {
+    this.routesFriendlyNamesRegex.set(routeRegex, name);
+  }
+
+  /**
+   * Specify a callback for the corresponding route.
+   * When a matching url is navigated to, the callback function is invoked to get the name to be displayed in the breadcrumb.
+   */
+  addCallbackForRoute(route: string, callback: (id: string) => string): void {
+    this.routesWithCallback.set(route, callback);
+  }
+
+  /**
+   * Specify a callback for the corresponding route matching a regular expression.
+   * When a mathing url is navigatedd to, the callback function is invoked to get the name to be displayed in the breadcrumb.
+   */
+  addCallbackForRouteRegex(routeRegex: string, callback: (id: string) => string): void {
+    this.routesWithCallbackRegex.set(routeRegex, callback);
+  }
+
+  /**
+   * Show the friendly name for a given route (url). If no match is found the url (without the leading '/') is shown.
+   *
+   * @param route
+   * @returns {*}
+   */
+  getFriendlyNameForRoute(route: string): string {
+    let name: string;
+    const routeEnd = route.substr(route.lastIndexOf('/') + 1, route.length);
+
+    this.routesFriendlyNames.forEach((value, key, map) => {
+      if (key === route) {
+        name = value;
+      }
+    });
+
+    this.routesFriendlyNamesRegex.forEach((value, key, map) => {
+      if (new RegExp(key).exec(route)) {
+        name = value;
+      }
+    });
+
+    this.routesWithCallback.forEach((value, key, map) => {
+      if (key === route) {
+        name = value(routeEnd);
+      }
+    });
+
+    this.routesWithCallbackRegex.forEach((value, key, map) => {
+      if (new RegExp(key).exec(route)) {
+        name = value(routeEnd);
+      }
+    });
+
+    return name ? name : routeEnd;
+  }
+
+  /**
+   * Specify a route (url) that should not be shown in the breadcrumb.
+   */
+  hideRoute(route: string): void {
+    if (this.hideRoutes.indexOf(route) === -1) {
+      this.hideRoutes.push(route);
+    }
+  }
+
+  /**
+   * Specify a route (url) regular expression that should not be shown in the breadcrumb.
+   */
+  hideRouteRegex(routeRegex: string): void {
+    if (this.hideRoutesRegex.indexOf(routeRegex) === -1) {
+      this.hideRoutesRegex.push(routeRegex);
+    }
+  }
+
+  /**
+   * Returns true if a route should be hidden.
+   */
+  isRouteHidden(route: string): boolean {
+    let hide = this.hideRoutes.indexOf(route) > -1;
+
+    this.hideRoutesRegex.forEach((value: any) => {
+      if (new RegExp(value).exec(route)) {
+        hide = true;
+      }
+    });
+
+    return hide;
+  }
+
+  /**
+   * Specify a route (url) that should not show the breadcrumbs component.
+   */
+  removeBreadcrumbsRoute(route: string): void {
+    if (this.noBreadcrumbsRoutes.indexOf(route) === -1) {
+      this.noBreadcrumbsRoutes.push(route);
+    }
+  }
+
+  /**
+   * Specify a route (url) regular expression that should not show the breadcrumbs component.
+   */
+  removeBreadcrumbsRouteRegex(routeRegex: string): void {
+    if (this.noBreadcrumbsRoutesRegex.indexOf(routeRegex) === -1) {
+      this.noBreadcrumbsRoutesRegex.push(routeRegex);
+    }
+  }
+
+  /**
+   * Returns true if a route should not show the breadcrumbs component.
+   */
+  breadcrumbsRemoved(route: string): boolean {
+    let remove = this.noBreadcrumbsRoutes.indexOf(route) > -1;
+
+    this.noBreadcrumbsRoutesRegex.forEach((value: any) => {
+      if (new RegExp(value).exec(route)) {
+        remove = true;
+      }
+    });
+
+    return remove;
+  }
+
+}

--- a/src/app/@theme/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/@theme/components/breadcrumbs/breadcrumbs.component.html
@@ -1,0 +1,10 @@
+<nb-card *ngIf="!isHidden &&  _urls?.length > 0">
+  <ul class="breadcrumb">
+    <li *ngFor="let url of _urls; let last = last" [ngClass]="{'breadcrumb-item': true, 'active': last}"> <!-- disable link of last item -->
+        <a role="button" *ngIf="!last && url == prefix" (click)="navigateTo('/')">{{url}}</a>
+        <a role="button" *ngIf="!last && url != prefix" (click)="navigateTo(url)">{{friendlyName(url)}}</a>
+        <a role="button" *ngIf="last && url == prefix" (click)="navigateTo(url)">{{friendlyName(url)}}</a>
+        <span *ngIf="last && url != prefix">{{friendlyName(url)}}</span>
+    </li>
+  </ul>
+</nb-card>

--- a/src/app/@theme/components/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/@theme/components/breadcrumbs/breadcrumbs.component.scss
@@ -1,0 +1,13 @@
+@import '../../../@theme/styles/themes';
+
+.breadcrumb {
+  background-color: transparent;
+  margin-bottom: 0;
+}
+.breadcrumb a {
+  cursor: pointer;
+  color: nb-theme(link-color) !important;
+}
+.breadcrumb a:hover {
+  color: nb-theme(link-color-hover) !important;
+}

--- a/src/app/@theme/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/@theme/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,0 +1,108 @@
+import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+
+import { BreadcrumbsService } from '../../../@core/utils/breadcrumbs.service';
+import { breadcrumbsConfig } from '../../../pages/breadcrumbs.config';
+
+@Component({
+  selector: 'ngx-breadcrumbs',
+  templateUrl: 'breadcrumbs.component.html',
+  styleUrls: ['./breadcrumbs.component.scss'],
+})
+export class BreadcrumbsComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() prefix: string = breadcrumbsConfig.prefix;
+
+  public isHidden = false;
+  public _urls: string[];
+  public _routerSubscription: any;
+
+  constructor(
+    private router: Router,
+    private breadcrumbService: BreadcrumbsService,
+  ) { }
+
+  ngOnInit(): void {
+    this._urls = new Array();
+
+    if (this.prefix.length > 0) {
+      this._urls.unshift(this.prefix);
+    }
+
+    this._routerSubscription = this.router.events.subscribe((navigationEnd: NavigationEnd) => {
+
+      if (navigationEnd instanceof NavigationEnd) {
+        this._urls.length = 0; // Fastest way to clear out array
+        this.generateBreadcrumbTrail(navigationEnd.urlAfterRedirects ? navigationEnd.urlAfterRedirects : navigationEnd.url);
+
+        this.hideIfNoBreadcrumbs();
+      }
+    });
+
+    breadcrumbsConfig.names.forEach((item) => {
+      this.breadcrumbService.addFriendlyNameForRoute(item.route, item.name);
+    });
+    breadcrumbsConfig.regexNames.forEach((item) => {
+      this.breadcrumbService.addFriendlyNameForRouteRegex(item.route, item.name);
+    });
+    breadcrumbsConfig.hide.forEach((item) => {
+      this.breadcrumbService.hideRoute(item.route);
+    });
+    breadcrumbsConfig.regexHide.forEach((item) => {
+      this.breadcrumbService.hideRouteRegex(item.route);
+    });
+    breadcrumbsConfig.noBreadcrumbs.forEach((item) => {
+      this.breadcrumbService.removeBreadcrumbsRoute(item.route);
+    });
+    breadcrumbsConfig.regexNoBreadcrumbs.forEach((item) => {
+      this.breadcrumbService.removeBreadcrumbsRouteRegex(item.route);
+    });
+
+    this._urls.length = 0;
+    this.generateBreadcrumbTrail(this.router.url);
+
+    this.hideIfNoBreadcrumbs();
+  }
+
+  ngOnChanges(changes: any): void {
+    if (!this._urls) {
+      return;
+    }
+
+    this._urls.length = 0;
+    this.generateBreadcrumbTrail(this.router.url);
+  }
+
+  generateBreadcrumbTrail(url: string): void {
+    if (!this.breadcrumbService.isRouteHidden(url)) {
+      // Add url to beginning of array (since the url is being recursively broken down from full url to its parent)
+      this._urls.unshift(url);
+    }
+
+    if (url.lastIndexOf('/') > 0) {
+      this.generateBreadcrumbTrail(url.substr(0, url.lastIndexOf('/'))); // Find last '/' and add everything before it as a parent route
+    } else if (this.prefix.length > 0) {
+      this._urls.unshift(this.prefix);
+    }
+  }
+
+  navigateTo(url: string): void {
+    this.router.navigateByUrl(url);
+  }
+
+  friendlyName(url: string): string {
+    return !url ? '' : this.breadcrumbService.getFriendlyNameForRoute(url);
+  }
+
+  ngOnDestroy(): void {
+    this._routerSubscription.unsubscribe();
+  }
+
+  private hideIfNoBreadcrumbs() {
+    if (this.breadcrumbService.breadcrumbsRemoved(this.router.url)) {
+      this.isHidden = true;
+    } else {
+      this.isHidden = false;
+    }
+  }
+
+}

--- a/src/app/@theme/components/index.ts
+++ b/src/app/@theme/components/index.ts
@@ -1,5 +1,6 @@
 export * from './header/header.component';
 export * from './footer/footer.component';
+export * from './breadcrumbs/breadcrumbs.component';
 export * from './search-input/search-input.component';
 export * from './tiny-mce/tiny-mce.component';
 export * from './theme-settings/theme-settings.component';

--- a/src/app/@theme/layouts/sample/sample.layout.ts
+++ b/src/app/@theme/layouts/sample/sample.layout.ts
@@ -37,6 +37,7 @@ import 'rxjs/add/operator/delay';
       </nb-sidebar>
 
       <nb-layout-column class="main-content">
+        <ngx-breadcrumbs></ngx-breadcrumbs>
         <ng-content select="router-outlet"></ng-content>
       </nb-layout-column>
 

--- a/src/app/@theme/theme.module.ts
+++ b/src/app/@theme/theme.module.ts
@@ -20,6 +20,7 @@ import {
 import {
   FooterComponent,
   HeaderComponent,
+  BreadcrumbsComponent,
   SearchInputComponent,
   ThemeSettingsComponent,
   ThemeSwitcherComponent,
@@ -55,6 +56,7 @@ const COMPONENTS = [
   ThemeSwitcherComponent,
   HeaderComponent,
   FooterComponent,
+  BreadcrumbsComponent,
   SearchInputComponent,
   ThemeSettingsComponent,
   TinyMCEComponent,

--- a/src/app/pages/breadcrumbs.config.ts
+++ b/src/app/pages/breadcrumbs.config.ts
@@ -1,0 +1,35 @@
+export const breadcrumbsConfig = {
+
+  // The Home link in breadcrumbs
+  prefix: 'Home',
+
+  // Replace route name with a friendly name
+  names: [
+    {route: '/pages/ui-features', name: 'UI Features'},
+  ],
+
+  // Replace route regular expression with a friendly name
+  regexNames: [
+    // {route: '', name: ''},
+  ],
+
+  // Hide route from breadcrumbs trail
+  hide: [
+    {route: '/pages'},
+  ],
+
+  // Hide route regular expression from breadcrumbs trail
+  regexHide: [
+    // {route: ''},
+  ],
+
+  // Remove the breadcrumbs component on these routes
+  noBreadcrumbs: [
+    {route: '/pages/dashboard'},
+  ],
+
+  // Remove the breadcrumbs component on these routes regular expression
+  regexNoBreadcrumbs: [
+    // {route: ''},
+  ],
+};

--- a/src/app/pages/forms/form-inputs/form-inputs.component.ts
+++ b/src/app/pages/forms/form-inputs/form-inputs.component.ts
@@ -1,12 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+
+import { BreadcrumbsService } from '../../../@core/utils/breadcrumbs.service';
 
 @Component({
   selector: 'ngx-form-inputs',
   styleUrls: ['./form-inputs.component.scss'],
   templateUrl: './form-inputs.component.html',
 })
-export class FormInputsComponent {
+export class FormInputsComponent implements OnInit {
 
   starRate = 2;
   heartRate = 4;
+
+  constructor(private breadcrumbs: BreadcrumbsService) {  }
+
+  ngOnInit() {
+    this.breadcrumbs.addFriendlyNameForRoute('/pages/forms/inputs', 'Forms Inputs');
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Feature

**What is the new behavior (if this is a feature change)?**
this PR automatically adds breadcrumbs to pages based on the current route.
this is a working demo
https://hatemhosny.github.io/ngx-admin-demos/#/pages/components/notifications

**Configuration:**
it works out of the box with route paths. Configurations to override the route names can be done in [`app/src/pages/breadcrumbs-config.ts`](https://github.com/hatemhosny/ngx-admin/blob/549fc150013292ef4eb092e91b3e9d827153e0bf/src/app/pages/breadcrumbs.config.ts), where you can change the prefix link name, add friendly names to routes (either directly or by regular expression), hide some routes from trail, or completely remove the component from some routes.

**More Info:**
This is based on [ng2-breadcrumb](https://github.com/gmostert/ng2-breadcrumb/), with many modifications

we essentially add `BreadcrumbsService` and `BreadcrumbsComponent`
the component displays the breadcrumbs trail, formatted using the theme colors.
the service can be injected to any other component to dynamically override the default route name (e.g. use post title), like [here](https://github.com/hatemhosny/ngx-admin/blob/549fc150013292ef4eb092e91b3e9d827153e0bf/src/app/pages/forms/form-inputs/form-inputs.component.ts)


**Examples:**
- All pages have "/pages" route hidden from breadcrumbs trail
- [automatic breadcrumbs from route path](https://hatemhosny.github.io/ngx-admin-demos/#/pages/components/notifications)
- [Add friendly name "UI Features instead of ui-features"](https://hatemhosny.github.io/ngx-admin-demos/#/pages/ui-features/buttons)
- [the whole component is removed in "/dashboard" route](https://hatemhosny.github.io/ngx-admin-demos/#/pages/dashboard)
- [dynamically override the breadcrumb name from another component "change `inputs` to `Form Inputs` from `form-inputs.component.ts`"](https://hatemhosny.github.io/ngx-admin-demos/#/pages/forms/inputs)
