### PR TITLE
Fix mistyped ngbDropdownMenu in some ngbDropdown ul elements

### DIFF
--- a/src/app/pages/components/notifications/notifications.component.html
+++ b/src/app/pages/components/notifications/notifications.component.html
@@ -13,7 +13,7 @@
             <button class="btn btn-primary" type="button" ngbDropdownToggle>
               {{ position }}
             </button>
-            <ul ngbDropdown class="dropdown-menu">
+            <ul ngbDropdownMenu class="dropdown-menu">
               <li class="dropdown-item" *ngFor="let p of positions" (click)="position = p">
                 {{ p }}
               </li>
@@ -26,7 +26,7 @@
             <button class="btn btn-primary" type="button" ngbDropdownToggle>
               {{ animationType }}
             </button>
-            <ul ngbDropdown class="dropdown-menu">
+            <ul ngbDropdownMenu class="dropdown-menu">
               <li class="dropdown-item" *ngFor="let at of animations" (click)="animationType = at">
                 {{ at }}
               </li>
@@ -60,7 +60,7 @@
             <button class="btn btn-primary" type="button" ngbDropdownToggle>
               {{ type }}
             </button>
-            <ul ngbDropdown class="dropdown-menu">
+            <ul ngbDropdownMenu class="dropdown-menu">
               <li class="dropdown-item" *ngFor="let t of types" (click)="type = t">{{ t }}</li>
             </ul>
           </div>

--- a/src/app/pages/dashboard/traffic/traffic.component.ts
+++ b/src/app/pages/dashboard/traffic/traffic.component.ts
@@ -13,7 +13,7 @@ import { NbThemeService } from '@nebular/theme';
                   [ngClass]="{ 'btn-success': currentTheme == 'default', 'btn-primary': currentTheme != 'default'}">
             {{ type }}
           </button>
-          <ul ngbDropdown class="dropdown-menu">
+          <ul ngbDropdownMenu class="dropdown-menu">
             <li class="dropdown-item" *ngFor="let t of types" (click)="type = t">{{ t }}</li>
           </ul>
         </div>


### PR DESCRIPTION
Some dropdown menu did not show up, because `ngbDropdown ` directive was used in the ul element instead of `ngbDropdownMenu`.

This issue appeared in the **notification** component page, and in the **traffic** section in the dashboard.

It works in the _live_ demo page, but did not work in my localhost before this correction.