### PR TITLE
fix - Change sidebar's z-index to overlap leaflap's controls

### DIFF
--- a/src/app/@theme/layouts/sample/sample.layout.scss
+++ b/src/app/@theme/layouts/sample/sample.layout.scss
@@ -110,7 +110,7 @@
   @include media-breakpoint-down(sm) {
 
     nb-sidebar.menu-sidebar {
-
+      z-index: 9999;
       margin-top: 0;
 
       /deep/ .main-container {


### PR DESCRIPTION
Updated z-index to remove the controls of leaflap's map over sidebar. https://prntscr.com/ir1b0s