### PR TITLE
Fix issue #1597 : Removed 'See All Nebular Icons' link, as there are …

### DIFF
--- a/src/app/pages/ui-features/icons/icons.component.html
+++ b/src/app/pages/ui-features/icons/icons.component.html
@@ -7,9 +7,6 @@
       <nb-card-body>
         <div class="icon" *ngFor="let icon of icons.nebular"><i class="{{ icon }}"></i></div>
       </nb-card-body>
-      <nb-card-footer>
-        <a href="https://www.npmjs.com/package/nebular-icons" target="_blank">See all Nebular icons</a>
-      </nb-card-footer>
     </nb-card>
 
     <nb-card>


### PR DESCRIPTION
…no more

Removed the footer containing 'See All Nebular Icons' link, as there are no more Nebular icons to display.

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
