### PR TITLE
fix(tslint): add correct semicolon option

### DIFF
--- a/src/app/@theme/components/index.ts
+++ b/src/app/@theme/components/index.ts
@@ -5,5 +5,5 @@ export * from './tiny-mce/tiny-mce.component';
 export * from './theme-settings/theme-settings.component';
 export * from './theme-switcher/theme-switcher.component';
 export * from './switcher/switcher.component';
-export * from './layout-direction-switcher/layout-direction-switcher.component'
-export * from './theme-switcher/themes-switcher-list/themes-switcher-list.component'
+export * from './layout-direction-switcher/layout-direction-switcher.component';
+export * from './theme-switcher/themes-switcher-list/themes-switcher-list.component';

--- a/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
+++ b/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
@@ -125,7 +125,7 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
     // TODO: review set data to styles object
     setTimeout(() => {
       this.invalidateGradientArcs();
-    })
+    });
   }
 
   private calculateVars() {

--- a/tslint.json
+++ b/tslint.json
@@ -74,6 +74,7 @@
     ],
     "radix": true,
     "semicolon": [
+      true,
       "always"
     ],
     "triple-equals": [


### PR DESCRIPTION
The first parameter in the semicolon option in tslint.json should be a boolean.

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes the typescript linter
