### PR TITLE
style: resize the navigation-button

### DIFF
--- a/src/app/@theme/components/header/header.component.scss
+++ b/src/app/@theme/components/header/header.component.scss
@@ -36,7 +36,7 @@
     .navigation {
       @include nb-ltr(padding-right, nb-theme(padding));
       @include nb-rtl(padding-left, nb-theme(padding));
-      font-size: 2.5rem;
+      font-size: 1.928571428571429rem;
       text-decoration: none;
 
       i {


### PR DESCRIPTION
resize the navigation button in order to have a definitive looking one by shrinking it 8px

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This is a workaround for the issue #1785. It shrinks the button so that it is rendered properly.