### PR TITLE
Issue 1810

### DIFF
--- a/src/app/@theme/layouts/sample/sample.layout.scss
+++ b/src/app/@theme/layouts/sample/sample.layout.scss
@@ -14,6 +14,13 @@
     width: $sidebar-width;
     overflow: hidden;
 
+    &.preload {
+      transition: none !important;
+      -webkit-transition: none !important;
+      -moz-transition: none !important;
+      -o-transition: none !important;
+    }
+
     &.collapsed {
       width: 0;
 

--- a/src/app/@theme/layouts/sample/sample.layout.ts
+++ b/src/app/@theme/layouts/sample/sample.layout.ts
@@ -148,7 +148,7 @@ export class SampleLayoutComponent implements OnDestroy {
 
     window.addEventListener('load', function () {
 
-      var settingsSidebarElement = this.settingsSidebarRef.element.nativeElement;
+      let settingsSidebarElement = this.settingsSidebarRef.element.nativeElement;
       settingsSidebarElement.classList.remove("preload");
       
     }.bind(this), false);

--- a/src/app/@theme/layouts/sample/sample.layout.ts
+++ b/src/app/@theme/layouts/sample/sample.layout.ts
@@ -61,7 +61,7 @@ import { StateService } from '../../../@core/data/state.service';
   `,
 })
 export class SampleLayoutComponent implements OnDestroy {
-  @ViewChild('settingsSidebar') settingsSidebar;
+  @ViewChild('settingsSidebar') settingsSidebarRef;
 
   subMenu: NbMenuItem[] = [
     {
@@ -148,9 +148,8 @@ export class SampleLayoutComponent implements OnDestroy {
 
     window.addEventListener('load', function () {
 
-      var element = 
-            this.settingsSidebar.element.nativeElement;
-      element.classList.remove("preload");
+      var settingsSidebarElement = this.settingsSidebarRef.element.nativeElement;
+      settingsSidebarElement.classList.remove("preload");
       
     }.bind(this), false);
   }

--- a/src/app/@theme/layouts/sample/sample.layout.ts
+++ b/src/app/@theme/layouts/sample/sample.layout.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, ViewChild } from '@angular/core';
 import { delay, withLatestFrom, takeWhile } from 'rxjs/operators';
 import {
   NbMediaBreakpoint,
@@ -49,7 +49,8 @@ import { StateService } from '../../../@core/data/state.service';
         <ngx-footer></ngx-footer>
       </nb-layout-footer>
 
-      <nb-sidebar class="settings-sidebar"
+      <nb-sidebar #settingsSidebar
+                   class="settings-sidebar preload"
                    tag="settings-sidebar"
                    state="collapsed"
                    fixed
@@ -60,6 +61,7 @@ import { StateService } from '../../../@core/data/state.service';
   `,
 })
 export class SampleLayoutComponent implements OnDestroy {
+  @ViewChild('settingsSidebar') settingsSidebar;
 
   subMenu: NbMenuItem[] = [
     {
@@ -143,6 +145,14 @@ export class SampleLayoutComponent implements OnDestroy {
       .subscribe(theme => {
         this.currentTheme = theme.name;
     });
+
+    window.addEventListener('load', function () {
+
+      var element = 
+            this.settingsSidebar.element.nativeElement;
+      element.classList.remove("preload");
+      
+    }.bind(this), false);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 It seems like transitions are triggered when page is loading. I looked at Nebular project and there is no toggle action while page is loading. Solution is to add class 'preload' with none transitions, which is removed after page is loaded, so the settings sidebar is hidden at the beginning and available to toggle after that.
