### PR TITLE
ci: test also on Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 dist: trusty
 
 node_js:
+  - '6'
   - '8'
-  - '9'
   - '10'
 
 branches:


### PR DESCRIPTION
Node.js 6 is supported until April 2019 and is still active LTS.

See https://github.com/nodejs/Release/blob/master/README.md