### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ dist: trusty
 
 node_js:
   - '8'
-  - '9'
   - '10'
+  - 'node'
 
 branches:
   only:


### PR DESCRIPTION
Odd releases are short living release branches and already reached their EOL.

See https://github.com/nodejs/Release/blob/master/README.md

Also we should add the current stable / latest which is 11(.1.0).