### PR TITLE
fix(menu): Menu item 'tabs' should be active after click (Close #1967)

### DIFF
--- a/src/app/pages/pages-menu.ts
+++ b/src/app/pages/pages-menu.ts
@@ -63,6 +63,7 @@ export const MENU_ITEMS: NbMenuItem[] = [
       {
         title: 'Tabs',
         link: '/pages/extra-components/tabs',
+        pathMatch: 'prefix',
       },
       {
         title: 'Calendar Kit',


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 
 #### Short description of what this resolves:
The problem is described in issue #1967 
Menu item 'tabs' is not shown as selected after a click, because url `/pages/extra-components/tabs` is not equal to `/pages/extra-components/tabs/tab1`.

By default `NbMenuItem` has a property `pathMatch` with value `full`: https://github.com/akveo/nebular/blob/master/src/framework/theme/components/menu/menu.service.ts#L80
Overriding this property allows to disable strict url comparison in `MenuService`: https://github.com/akveo/nebular/blob/master/src/framework/theme/components/menu/menu.service.ts#L378