### PR TITLE
fix: set curor type pointer for toggle settings button 

### DIFF
--- a/src/app/@theme/components/toggle-settings-button/toggle-settings-button.component.scss
+++ b/src/app/@theme/components/toggle-settings-button/toggle-settings-button.component.scss
@@ -12,6 +12,7 @@
     padding: 0;
     text-align: center;
     border: none;
+    cursor: pointer;
     transition: transform 0.3s ease, background-image 0.3s ease;
     transform: translate(0, -50%);
     z-index: 998;


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
#2109 
 #### Short description of what this resolves:
Set the cursor type to "pointer" when hovering on the toggle-settings-button