### PR TITLE
fix(typography): prevent bootstrap color override

### DIFF
--- a/src/app/pages/ui-features/typography/typography.component.html
+++ b/src/app/pages/ui-features/typography/typography.component.html
@@ -123,10 +123,10 @@
               Far far away, behind the your awesomeness.
             </div>
           </div>
-          <div class="item text-body">
+          <div class="item text-basic">
             <div class="color bg-body"></div>
             <div>
-              <h5 class="text-body">Body Text</h5>
+              <h5 class="text-basic">Body Text</h5>
               Far far away, behind the your awesomeness.
             </div>
           </div>

--- a/src/app/pages/ui-features/typography/typography.component.scss
+++ b/src/app/pages/ui-features/typography/typography.component.scss
@@ -100,6 +100,10 @@
     }
   }
 
+  .text-basic {
+    color: nb-theme(text-basic-color);
+  }
+
   .text-link {
     color: nb-theme(link-text-color);
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Use different class for basic text showcase. Bootstrap has !important
declaration in `text-body` class