### PR TITLE
fix(auth routing): scene may cause 404

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,7 +21,8 @@ const routes: Routes = [
     children: [
       {
         path: '',
-        component: NbLoginComponent,
+        redirectTo: 'login',
+        pathMatch: 'full',
       },
       {
         path: 'login',


### PR DESCRIPTION
When direct to localhost:4200/auth , it shows the login page . 
Then click 'Register' to register page . It will cause 404 beacuse the routerLink of login.component.html is '../register' .

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
use 'redirectTo' replace 'component'