### PR TITLE
fix(404 page): set correct base href

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <title>404</title>
 
-  <base href="/nebular/">
+  <base href="/ngx-admin/">
 
   <script type="text/javascript" src="assets/ghspa.js"></script>
 </head>


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes accessing docs pages by direct link. Nebular uses special ghspa
script so we can't use it for ngx-admin.