### PR TITLE
expanded variable made public

### DIFF
--- a/src/app/pages/dashboard/rooms/rooms.component.ts
+++ b/src/app/pages/dashboard/rooms/rooms.component.ts
@@ -20,7 +20,7 @@ import { map } from 'rxjs/operators';
 export class RoomsComponent implements OnDestroy {
 
   @HostBinding('class.expanded')
-  private expanded: boolean;
+  public expanded: boolean;
   private selected: number;
 
   isDarkTheme: boolean;


### PR DESCRIPTION
because it is throwing error while building in production with 
`ng build --prod`
 
 #### Short description of what this resolves:
- [x] It solves issue #5557 