### PR TITLE
Fix to issue #5559

### DIFF
--- a/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
+++ b/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
@@ -80,7 +80,7 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
     arcTranslateStr: 'translate(0, 0)',
     clipPathStr: '',
     gradArcs: [],
-    nonSelectedArc:{
+    nonSelectedArc: {
       color: this.disableArcColor,
       d: `M ${this.radius},${this.radius}
        L ${this.radius},${3 * this.radius}

--- a/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
+++ b/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
@@ -74,12 +74,21 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
   pinRadius = 10;
   colors: any = [];
 
+  angle = this.bottomAngleRad / 2 + (1 - this.getValuePercentage()) * (2 * Math.PI - this.bottomAngleRad);
   styles = {
     viewBox: '0 0 300 300',
     arcTranslateStr: 'translate(0, 0)',
     clipPathStr: '',
     gradArcs: [],
-    nonSelectedArc: {},
+    nonSelectedArc:{
+      color: this.disableArcColor,
+      d: `M ${this.radius},${this.radius}
+       L ${this.radius},${3 * this.radius}
+       A ${2 * this.radius},${2 * this.radius}
+       1 ${this.angle > Math.PI ? '1' : '0'} 0
+       ${this.radius + this.radius * 2 * Math.sin(this.angle)},${this.radius + this.radius * 2 * Math.cos(this.angle)}
+       Z`,
+    },
     thumbPosition: { x: 0, y: 0 },
     blurRadius: 15,
   };


### PR DESCRIPTION
Fix for issue #5559
styles variable changed from

```typescript
styles = {
    viewBox: '0 0 300 300',
    arcTranslateStr: 'translate(0, 0)',
    clipPathStr: '',
    gradArcs: [],
    nonSelectedArc: {},
    thumbPosition: { x: 0, y: 0 },
    blurRadius: 15,
  };
```

to 

```typescript
angle = this.bottomAngleRad / 2 + (1 - this.getValuePercentage()) * (2 * Math.PI - this.bottomAngleRad);
  styles = {
    viewBox: '0 0 300 300',
    arcTranslateStr: 'translate(0, 0)',
    clipPathStr: '',
    gradArcs: [],
    nonSelectedArc: {
      color: this.disableArcColor,
      d: `M ${this.radius},${this.radius}
       L ${this.radius},${3 * this.radius}
       A ${2 * this.radius},${2 * this.radius}
       1 ${this.angle > Math.PI ? '1' : '0'} 0
       ${this.radius + this.radius * 2 * Math.sin(this.angle)},${this.radius + this.radius * 2 * Math.cos(this.angle)}
       Z`,
    },
    thumbPosition: { x: 0, y: 0 },
    blurRadius: 15,
  };
```


 #### Short description of what this resolves:
- It solves issue #5559 