### PR TITLE
fix(bundles): hide old price if no discount

### DIFF
--- a/docs/app/@core/data/service/bundles.service.ts
+++ b/docs/app/@core/data/service/bundles.service.ts
@@ -91,7 +91,7 @@ export class BundlesService {
             storeUrl: `${this.STORE}/${item.handle}`,
             tags: item.tags,
             title: item.title,
-            description: (item.body_html as string).trim().replace(/^<p>/, '').replace(/<\/p>$/, ''),
+            description: (item.body_html as string).trim().replace(/<(?:.|\n)*?>/gm, ' ').replace(/  +/gm, ' '),
             variants: item.variants.map(variant => {
               return {
                 available: variant.available,

--- a/docs/app/pages/home/backend-bundles-section/backend-bundles-section.component.html
+++ b/docs/app/pages/home/backend-bundles-section/backend-bundles-section.component.html
@@ -34,7 +34,9 @@
             </a>
           </p>
           <div class="package-card__price-wrapper">
-            <span class="package-card__price package-card__price--old">${{ (product.variants | license:selectedLicenseType).compare_at_price }}</span>
+            <span class="package-card__price package-card__price--old" *ngIf="shouldShowOldPrice(product.variants, selectedLicenseType)">
+              ${{ (product.variants | license:selectedLicenseType).compare_at_price }}
+            </span>
             <span class="package-card__price">${{ (product.variants | license:selectedLicenseType).price }}</span>
           </div>
           <a href="{{ product.storeUrl }}?utm_source=ngx_admin_landing&utm_medium=buy_bundle_{{ selectedLicenseType }}"

--- a/docs/app/pages/home/backend-bundles-section/backend-bundles-section.component.ts
+++ b/docs/app/pages/home/backend-bundles-section/backend-bundles-section.component.ts
@@ -10,8 +10,15 @@ import { Observable } from 'rxjs';
 import { delay, filter, take } from 'rxjs/operators';
 import { NB_WINDOW } from '@nebular/theme';
 
-import { BUNDLE_LICENSE, BundlesService, Feature, Product } from '../../../@core/data/service/bundles.service';
+import {
+  BUNDLE_LICENSE,
+  BundlesService,
+  Feature,
+  Product,
+  ProductVariant,
+} from '../../../@core/data/service/bundles.service';
 import { Descriptions, DescriptionsService } from '../../../@core/data/service/descriptions.service';
+import { LicensePipe } from '../backend-bundles-section/license.pipe';
 
 @Component({
   selector: 'ngx-backend-bundles-section',
@@ -34,7 +41,8 @@ export class BackendBundlesSectionComponent implements AfterViewInit {
               private bundlesService: BundlesService,
               private activatedRoute: ActivatedRoute,
               private el: ElementRef<HTMLElement>,
-              @Inject(NB_WINDOW) private window) {
+              @Inject(NB_WINDOW) private window,
+              private licensePipe: LicensePipe) {
   }
 
   ngAfterViewInit() {
@@ -47,5 +55,11 @@ export class BackendBundlesSectionComponent implements AfterViewInit {
       .subscribe((fragment: string) => {
         this.window.scrollTo(0, this.el.nativeElement.offsetTop);
       });
+  }
+
+  shouldShowOldPrice(variants: ProductVariant[], selectedLicenseType: string): boolean {
+    const product = this.licensePipe.transform(variants, selectedLicenseType);
+
+    return !!parseFloat(product.compare_at_price);
   }
 }

--- a/docs/app/pages/home/landing-home.module.ts
+++ b/docs/app/pages/home/landing-home.module.ts
@@ -54,6 +54,9 @@ const COMPONENTS = [
     SwiperModule,
     LandingHomeRoutingModule,
   ],
+  providers: [
+    ...PIPES,
+  ],
 })
 export class LandingHomeModule {
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Hides crossed old price if it's 0 or something else converting to false.
Also changes item description paragraph tag reg epx to any tag reg exp as there was other tags used in description.