### PR TITLE
fix(analytics): analytics.service check whether ga function exists

### DIFF
--- a/src/app/@core/utils/analytics.service.ts
+++ b/src/app/@core/utils/analytics.service.ts
@@ -10,7 +10,12 @@ export class AnalyticsService {
   private enabled: boolean;
 
   constructor(private location: Location, private router: Router) {
-    this.enabled = false;
+    this.enabled = true;
+    this.handleGaAvailability();
+  }
+
+  private handleGaAvailability() {
+    this.enabled = (typeof ga === 'function');
   }
 
   trackPageViews() {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This PR resolves issue #5523.

Once the analytics service is run it checks whether ga is actually defined (and a valid function). If that's not the case Google Analytics is disabled., therefore not throwing an error in the console.

The ga function can be blocked by an AdBlocker, leading to the prior bug.