### PR TITLE
fix(temperature-dragger): update getUrlPath to return fragment

### DIFF
--- a/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.html
+++ b/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.html
@@ -19,8 +19,8 @@
     </defs>
     <g [attr.transform]="styles.arcTranslateStr">
 
-      <g class="toClip" [attr.clip-path]="getUrlPath('#sliderClip')">
-        <g class="toFilter" [attr.filter]="getUrlPath('#blurFilter')">
+      <g class="toClip" [attr.clip-path]="getUrlFragment('#sliderClip')">
+        <g class="toFilter" [attr.filter]="getUrlFragment('#blurFilter')">
           <path [attr.d]="arc.d" [attr.fill]="off ? styles.nonSelectedArc.color : arc.color" *ngFor="let arc of styles.gradArcs"></path>
         </g>
         <!-- ngFor is a quirk fix for webkit rendering issues -->

--- a/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
+++ b/src/app/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
@@ -129,11 +129,8 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
     this.invalidatePinPosition();
   }
 
-  getUrlPath(id: string) {
-    const baseHref = this.locationStrategy.getBaseHref().replace(/\/$/, '');
-    const path = this.location.path().replace(/\/$/, '');
-
-    return `url(${baseHref}${path}${id}${this.svgControlId})`;
+  getUrlFragment(id: string) {
+    return `url(${id}${this.svgControlId})`;
   }
 
   private invalidate(): void {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

This PR resolves issue #5758.

Sets the url path for clipPath and blurFilter to a fragment to let the browser successfully find the element by id regardless of whether useHash is true or false. getUrlPath is renamed to getUrlFragment to reflect the change.