### PR TITLE
Update success and warning input text/color

### DIFF
--- a/src/app/pages/forms/form-inputs/form-inputs.component.html
+++ b/src/app/pages/forms/form-inputs/form-inputs.component.html
@@ -37,8 +37,8 @@
       <nb-card-header>Validation States</nb-card-header>
       <nb-card-body>
         <input type="text" nbInput fullWidth status="info"  placeholder="Input with Info">
-        <input type="text" nbInput fullWidth status="success"  placeholder="Warning Input">
-        <input type="text" nbInput fullWidth status="warning"  placeholder="Danger Input">
+        <input type="text" nbInput fullWidth status="success"  placeholder="Success Input">
+        <input type="text" nbInput fullWidth status="warning"  placeholder="Warning Input">
         <input type="text" nbInput fullWidth status="danger" placeholder="Danger Input">
         <input type="text" nbInput fullWidth status="primary"  placeholder="Input with Primary">
         <div class="validation-checkboxes">


### PR DESCRIPTION
 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 
 #### Short description of what this resolves:
*Fix wrong text display*.


Before :

![image](https://user-images.githubusercontent.com/36853313/108192580-bb43cf00-7114-11eb-87e7-67d8a114e77f.png)

After : 

![image](https://user-images.githubusercontent.com/36853313/108192646-d0206280-7114-11eb-8545-eacc4e74d222.png)
