### PR TITLE
fix(npm-i-issue): remove node-sass pacakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ng2-completer": "^9.0.1",
     "ng2-smart-table": "^1.6.0",
     "ngx-echarts": "^4.2.2",
-    "node-sass": "^4.14.1",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "roboto-fontface": "0.8.0",


### PR DESCRIPTION
Angular already has `@angular-devkit/build-angular` in package.json has already sass-loader as an depndendency in `package-lock.json` and `node-sass` is not required and it is giving errors
describing requirement of python2 package

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [ ] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
